### PR TITLE
Add config to auth struct

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,9 @@ jobs:
           k3d image import patoarvizu/vault-dynamic-configuration-operator:latest
           kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/master/prometheus-operator/crds.yaml
           sleep 10
-          kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/add-kubernetes-config/vault/vault-operator.yaml
+          kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/master/vault/vault-operator.yaml
           sleep 10
-          kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/add-kubernetes-config/vault/vault-cluster-kubernetes-and-db.yaml
+          kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/master/vault/vault-cluster-kubernetes-and-db.yaml
           sleep 10
           kubectl apply -f test/manifests/namespaces/test.yaml
           helm install vault-dynamic-configuration-operator helm/vault-dynamic-configuration-operator/ -n vault

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,13 +79,13 @@ jobs:
         name: Run all tests
         command: |
           export KUBECONFIG=~/.k3d/k3s-default-config
-          k3d cluster create --wait
+          k3d cluster create --image rancher/k3s:v1.21.8-k3s1 # --k3s-server-arg "--kube-apiserver-arg=feature-gates=ServerSideApply=false"
           k3d image import patoarvizu/vault-dynamic-configuration-operator:latest
           kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/master/prometheus-operator/crds.yaml
           sleep 10
-          kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/master/vault/vault-operator.yaml
+          kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/add-kubernetes-config/vault/vault-operator.yaml
           sleep 10
-          kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/master/vault/vault-cluster-kubernetes-and-db.yaml
+          kubectl apply -f https://raw.githubusercontent.com/patoarvizu/common-manifests/add-kubernetes-config/vault/vault-cluster-kubernetes-and-db.yaml
           sleep 10
           kubectl apply -f test/manifests/namespaces/test.yaml
           helm install vault-dynamic-configuration-operator helm/vault-dynamic-configuration-operator/ -n vault

--- a/controllers/serviceaccount_controller.go
+++ b/controllers/serviceaccount_controller.go
@@ -66,8 +66,9 @@ type BankVaultsConfig struct {
 }
 
 type Auth struct {
-	Roles []Role `json:"roles"`
-	Type  string `json:"type"`
+	Roles  []Role                 `json:"roles"`
+	Type   string                 `json:"type"`
+	Config map[string]interface{} `json:"config,omitempty"`
 }
 
 type Policy struct {


### PR DESCRIPTION
Add a `Config` field to the `Auth` struct, since adding specific configuration may be required for deploying on Kubernetes >= 1.21 and Vault <= 1.9 ([source](https://www.vaultproject.io/docs/auth/kubernetes#kubernetes-1-21)).